### PR TITLE
Feat/news page

### DIFF
--- a/db/db.js
+++ b/db/db.js
@@ -9,4 +9,4 @@ var config = process.env.DATABASE_URL || process.env.DB_LOCAL;
 
 var pgp = require('pg-promise')();
 
-module.exports = pgp(config);
+// module.exports = pgp(config);

--- a/react-client/src/NewsPage/NewsArticleEntry.jsx
+++ b/react-client/src/NewsPage/NewsArticleEntry.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Votes from './Votes.jsx';
+
+export default (props) => {
+  let { likes, dislikes, title, url, source, description } = props.article;
+  return (
+    <div>
+      <Votes likes={likes} dislikes={dislikes} />
+      <div className="well col-lg-11 col-md-11 col-sm-10 col-xs-10">
+        <a href={url}>
+          <h4>{title}</h4>
+        </a>
+          <span>{description}</span>
+          <br />
+          <span>- {source}</span>
+      </div>
+    </div>
+  )
+}

--- a/react-client/src/NewsPage/NewsBoard.jsx
+++ b/react-client/src/NewsPage/NewsBoard.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import NewsArticleEntry from './NewsArticleEntry.jsx';
+import { fetchArticles } from './newsActions';
+
+export class NewsBoard extends React.Component {
+  componentWillMount() {
+    const { dispatch, getArticles } = this.props;
+    getArticles();
+  }
+
+  render() {
+    const { articles } = this.props;
+    if (articles && articles.length > 0) {
+      console.log('toBe mapped', articles)
+      return (
+        <div className="col-md-12">
+          <ul className="nav nav-tabs">
+            <li className="active">
+              <a href="#">Top</a>
+            </li>
+            <li>
+              <a href="#">Trending</a>
+            </li>
+            <li>
+              <a href="#">New</a>
+            </li>
+          </ul>
+          {articles.map((article) => 
+            <NewsArticleEntry key={article.publishedAt} article={article} />
+          )}
+        </div>
+      )
+    } else {
+      return (
+        <div className="col-md-12">
+          <ul className="nav nav-tabs">
+            <li className="active">
+              <a href="#">Top</a>
+            </li>
+            <li>
+              <a href="#">Trending</a>
+            </li>
+            <li>
+              <a href="#">New</a>
+            </li>
+          </ul>
+        Fetching articles!
+        </div>
+      )
+      
+    }
+  }
+};
+
+const mapStateToProps = (state) => {
+  return {
+    articles: state.newsReducer.articles
+  };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    getArticles: () => dispatch(fetchArticles())
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(NewsBoard);

--- a/react-client/src/NewsPage/NewsBoard.jsx
+++ b/react-client/src/NewsPage/NewsBoard.jsx
@@ -11,9 +11,9 @@ export class NewsBoard extends React.Component {
   }
 
   render() {
-    const { articles } = this.props.articles;
+    console.log(this.props)
+    const { articles } = this.props.news;
     if (articles && articles.length > 0) {
-      console.log('toBe mapped', articles)
       return (
         <div className="col-md-12">
           <ul className="nav nav-tabs">
@@ -56,7 +56,7 @@ export class NewsBoard extends React.Component {
 
 const mapStateToProps = (state) => {
   return {
-    articles: state.news
+    news: state.news
   };
 };
 

--- a/react-client/src/NewsPage/NewsBoard.jsx
+++ b/react-client/src/NewsPage/NewsBoard.jsx
@@ -11,7 +11,7 @@ export class NewsBoard extends React.Component {
   }
 
   render() {
-    const { articles } = this.props;
+    const { articles } = this.props.articles;
     if (articles && articles.length > 0) {
       console.log('toBe mapped', articles)
       return (
@@ -56,7 +56,7 @@ export class NewsBoard extends React.Component {
 
 const mapStateToProps = (state) => {
   return {
-    articles: state.newsReducer.articles
+    articles: state.news
   };
 };
 

--- a/react-client/src/NewsPage/Votes.jsx
+++ b/react-client/src/NewsPage/Votes.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default (props) => (
+  <div className="text-center col-lg-1 col-md-1 col-sm-2 col-xs-2">
+
+    <button className="btn btn-lg btn-block">
+      <span>{props.likes} </span>
+      <span className="glyphicon glyphicon-triangle-top" />
+    </button>
+    <button className="btn btn-lg btn-block">
+      <span>{props.dislikes} </span>
+      <span className="glyphicon glyphicon-triangle-bottom" />
+    </button>
+  </div>
+);

--- a/react-client/src/NewsPage/__tests__/NewsPageSpec.js
+++ b/react-client/src/NewsPage/__tests__/NewsPageSpec.js
@@ -24,7 +24,7 @@ describe('News Actions', () => {
 describe('News Components', () => {
   describe('NewsBoard', () => {
     it('should render Top, Trending, and New tabs', () => {
-      const wrapper = shallow(<NewsBoard getArticles={fetchArticles}/>);
+      const wrapper = shallow(<NewsBoard getArticles={fetchArticles} news={{}}/>);
       expect(wrapper.find('div').length).toBe(1);
       expect(wrapper.find('div').children('ul').children('li').length).toBe(3);
       expect(wrapper.contains(<a href="#">Top</a>)).toBe(true);
@@ -33,7 +33,7 @@ describe('News Components', () => {
     });
 
     it('should render Fetching Articles', () => {
-      const wrapper = shallow(<NewsBoard getArticles={fetchArticles}/>);
+      const wrapper = shallow(<NewsBoard getArticles={fetchArticles} news={{}}/>);
       expect(wrapper.contains('Fetching articles!')).toBe(true);
     });
   });

--- a/react-client/src/NewsPage/__tests__/NewsPageSpec.js
+++ b/react-client/src/NewsPage/__tests__/NewsPageSpec.js
@@ -1,0 +1,83 @@
+import { shallow } from 'enzyme';
+import { NewsBoard } from '../NewsBoard.jsx';
+import NewsArticleEntry from '../NewsArticleEntry.jsx';
+import Votes from '../Votes';
+import { receivedArticles, fetchingArticles, fetchArticles } from '../newsActions';
+import reduce from '../newsReducer';
+import React from 'react';
+describe('News Actions', () => {
+  it('should have RECEIVED_ARTICLES action', () => {
+    const expectedAction = {
+      type: 'RECEIVED_ARTICLES'
+    };
+    expect(receivedArticles()).toEqual(expectedAction);
+  });
+
+  it('should have FETCHING_ARTICLES action', () => {
+    const expectedAction = {
+      type: 'FETCHING_ARTICLES'
+    };
+    expect(fetchingArticles()).toEqual(expectedAction);
+  });
+});
+
+describe('News Components', () => {
+  describe('NewsBoard', () => {
+    it('should render Top, Trending, and New tabs', () => {
+      const wrapper = shallow(<NewsBoard getArticles={fetchArticles}/>);
+      expect(wrapper.find('div').length).toBe(1);
+      expect(wrapper.find('div').children('ul').children('li').length).toBe(3);
+      expect(wrapper.contains(<a href="#">Top</a>)).toBe(true);
+      expect(wrapper.contains(<a href="#">Trending</a>)).toBe(true);
+      expect(wrapper.contains(<a href="#">New</a>)).toBe(true);
+    });
+
+    it('should render Fetching Articles', () => {
+      const wrapper = shallow(<NewsBoard getArticles={fetchArticles}/>);
+      expect(wrapper.contains('Fetching articles!')).toBe(true);
+    });
+  });
+
+  describe('NewsArticleEntry', () => {
+    const article =   {
+      "author": "Sarah Perez",
+      "title": "Walmart to lower prices on a million online-only items if you opt for store pickup over shipping",
+      "description": "Walmart.com is preparing to launch a new feature called \"Pickup Discount\" that will lower the prices on up to one million online-only items if the customer..",
+      "url": "https://techcrunch.com/2017/04/11/walmart-to-lower-prices-on-a-million-online-only-items-if-you-opt-for-store-pickup-over-shipping/",
+      "urlToImage": "https://tctechcrunch2011.files.wordpress.com/2016/01/walmart-truckclose-up-side-view_129821854433586541.jpg?w=764&h=400&crop=1",
+      "publishedAt": "2017-04-12T04:01:08Z",
+      "source": "techcrunch",
+      "likes": 12,
+      "dislikes": 3
+    };
+    it('should render the title', () => {
+      const wrapper = shallow(<NewsArticleEntry article={article}/>);
+      expect(wrapper.contains('Walmart to lower prices on a million online-only items if you opt for store pickup over shipping')).toBe(true);
+    });
+    it('should render the description', () => {
+      const wrapper = shallow(<NewsArticleEntry article={article}/>);
+      expect(wrapper.contains('Walmart.com is preparing to launch a new feature called \"Pickup Discount\" that will lower the prices on up to one million online-only items if the customer..')).toBe(true);
+    });
+    it('should render the source', () => {
+      const wrapper = shallow(<NewsArticleEntry article={article}/>);
+      expect(wrapper.contains('techcrunch')).toBe(true);
+    });
+    it('should include the href', () => {
+      const wrapper = shallow(<NewsArticleEntry article={article}/>);
+      expect(wrapper.contains(<a href="https://techcrunch.com/2017/04/11/walmart-to-lower-prices-on-a-million-online-only-items-if-you-opt-for-store-pickup-over-shipping/">
+          <h4>Walmart to lower prices on a million online-only items if you opt for store pickup over shipping</h4></a>)).toBe(true);
+    })
+  })
+  describe('Votes', () => {
+    it('should render 2 buttons', () => {
+      const wrapper = shallow(<Votes />);
+      expect(wrapper.find('button').length).toBe(2);
+    });
+    it('should render likes and dislikes', () => {
+      const wrapper = shallow(<Votes likes={12} dislikes={3}/>);
+      expect(wrapper.contains(<span>12 </span>)).toBe(true);
+      expect(wrapper.contains(<span>3 </span>)).toBe(true);
+    });
+  });
+
+})

--- a/react-client/src/NewsPage/newsActions.js
+++ b/react-client/src/NewsPage/newsActions.js
@@ -1,0 +1,21 @@
+export const fetchingArticles = () => {
+  return {
+    type: "FETCHING_ARTICLES"
+  };
+};
+
+export const receivedArticles = () => {
+  return {
+    type: "RECEIVED_ARTICLES"
+  };
+};
+
+export const fetchArticles = () => {
+  return (dispatch) => {
+    dispatch(fetchingArticles());
+    // Mimics axios request to server
+    setTimeout(() => {
+      dispatch(receivedArticles());
+    }, 1000);
+  }
+}

--- a/react-client/src/NewsPage/newsReducer.js
+++ b/react-client/src/NewsPage/newsReducer.js
@@ -1,0 +1,75 @@
+const initialState = {
+  fetchingArticles: false, 
+  articles: [],
+}
+
+const articleDummyData = [
+  {
+    "author": "Brian Heater",
+    "title": "Don’t run commercials designed to trigger smart assistants",
+    "description": "A well-known fast food chain – let’s call them Kurger Bing – is debuting a new 15 second ad today set to start running nationally. It starts off simply..",
+    "url": "https://techcrunch.com/2017/04/12/no-thank-you/",
+    "urlToImage": "https://tctechcrunch2011.files.wordpress.com/2017/04/img_2492.jpg?w=764&h=400&crop=1",
+    "publishedAt": "2017-04-12T16:05:43Z",
+    "source": "techcrunch",
+    "likes": 23,
+    "dislikes": 0
+  },
+  {
+    "author": "Josh Constine",
+    "title": "Facebook Messenger hits 1.2 billion monthly users, up from 1B in July",
+    "description": "Normally adding 200 million users in 8 months to a product that already has a billion would reduce the average engagement, but most apps don't have Facebook..",
+    "url": "https://techcrunch.com/2017/04/12/messenger/",
+    "urlToImage": "https://tctechcrunch2011.files.wordpress.com/2017/04/facebook-messenger-1-2-billion-users.png?w=764&h=400&crop=1",
+    "publishedAt": "2017-04-12T16:00:33Z",
+    "source": "techcrunch",
+    "likes": 7,
+    "dislikes": 2
+  },
+  {
+    "author": "Sarah Buhr",
+    "title": "Qualtrics waits on that IPO, raises $180 million at a $2.5 billion valuation instead",
+    "description": "That Qualtrics IPO many have been expecting is on hold for now. The online market research platform has just raised its third round for $180 million at a..",
+    "url": "https://techcrunch.com/2017/04/12/qualtrics-waits-on-that-ipo-raises-180-million-at-a-2-5-billion-valuation-instead/",
+    "urlToImage": "https://tctechcrunch2011.files.wordpress.com/2017/04/qualtrics_ryansmith-1_1024-e1491942393932.jpg?w=758&h=400&crop=1",
+    "publishedAt": "2017-04-12T12:00:38Z",
+    "source": "techcrunch",
+    "likes": 11,
+    "dislikes": 4
+  },
+  {
+    "author": "Sarah Perez",
+    "title": "Walmart to lower prices on a million online-only items if you opt for store pickup over shipping",
+    "description": "Walmart.com is preparing to launch a new feature called \"Pickup Discount\" that will lower the prices on up to one million online-only items if the customer..",
+    "url": "https://techcrunch.com/2017/04/11/walmart-to-lower-prices-on-a-million-online-only-items-if-you-opt-for-store-pickup-over-shipping/",
+    "urlToImage": "https://tctechcrunch2011.files.wordpress.com/2016/01/walmart-truckclose-up-side-view_129821854433586541.jpg?w=764&h=400&crop=1",
+    "publishedAt": "2017-04-12T04:01:08Z",
+    "source": "techcrunch",
+    "likes": 12,
+    "dislikes": 3
+  }
+]
+
+const articles = (state = initialState, action) => {
+  switch(action.type) {
+    case "FETCHING_ARTICLES": {
+      return {
+        ...state,
+        fetchingArticles: true
+      }
+      
+    }
+    case "RECEIVED_ARTICLES" : {
+      return {
+        ...state,
+        articles: articleDummyData,
+        fetchingArticles: false
+      }
+    }
+    default: {
+      return state;
+    }
+  }
+}
+
+export default articles;

--- a/react-client/src/components/App.jsx
+++ b/react-client/src/components/App.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import ProjectBoard from '../ProjectIdeas/ProjectBoard.jsx';
 import NavBar from '../NavBar/NavBar.jsx';
 import TestComponent from '../TestFeature/TestComponent.jsx';
+import NewsBoard from '../NewsPage/NewsBoard.jsx';
 
 class App extends React.Component {
 
@@ -10,7 +11,7 @@ class App extends React.Component {
     return (
       <div>
         <NavBar />
-        <ProjectBoard />
+        <NewsBoard />
       </div>
     );
   }

--- a/react-client/src/rootReducers.js
+++ b/react-client/src/rootReducers.js
@@ -2,11 +2,13 @@ import { combineReducers } from 'redux';
 
 import projectReducer from './ProjectIdeas/projectReducer';
 import testReducer from './TestFeature/testReducer';
+import newsReducer from './NewsPage/newsReducer';
 
 const appReducer = combineReducers({
   // all reducers in project
   testReducer,
   projects: projectReducer,
+  newsReducer,
 });
 
 const rootReducer = (state, action) => {

--- a/react-client/src/rootReducers.js
+++ b/react-client/src/rootReducers.js
@@ -8,7 +8,7 @@ const appReducer = combineReducers({
   // all reducers in project
   testReducer,
   projects: projectReducer,
-  newsReducer,
+  news: newsReducer,
 });
 
 const rootReducer = (state, action) => {

--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,7 @@ const session = require('express-session');
 const pgSession = require('connect-pg-simple')(session);
 const port = process.env.PORT || 3000;
 const pgp = require('pg-promise')();
-// const local = {
+// const config = {
 //   host: 'localhost',
 //   port: 5432,
 //   database: 'gecko'


### PR DESCRIPTION
This request includes the NewsPage view. Currently it displays four articles from dummy data in the newsReducer file. The Votes component has been duplicated into the NewsPage folder, it should be refactored later into a shared components files. 

Included with this pull request:
NewsBoard component, 
NewsArticleEntry component,
newsActions, 
newsReducer, 
duplicate Votes component, 
tests for the NewsPage view, 
